### PR TITLE
add OpenBSD to the .dll.config dllmap

### DIFF
--- a/Source/SharpFont/SharpFont.dll.config
+++ b/Source/SharpFont/SharpFont.dll.config
@@ -3,5 +3,6 @@
 	<dllmap dll="freetype6.dll">
 		<dllentry os="linux" dll="libfreetype.so.6" />
 		<dllentry os="osx" dll="/Library/Frameworks/Mono.framework/Libraries/libfreetype.6.dylib" />
+		<dllentry os="openbsd" dll="libfreetype.so" />
 	</dllmap>
 </configuration>


### PR DESCRIPTION
simple addition with platform-specific convention